### PR TITLE
Adding support for FA5 specific menu classes ("fas", "fab" etc.)

### DIFF
--- a/n9m-font-awesome-5.php
+++ b/n9m-font-awesome-5.php
@@ -116,7 +116,7 @@ class FontAwesomeFive {
 
     function nav_menu_css_class( $classes ){
         if( is_array( $classes ) ){
-            $tmp_classes = preg_grep( '/^(fa)(-\S+)?$/i', $classes );
+            $tmp_classes = preg_grep( '/^(fa|fas|far|fal|fad|fab)(-\S+)?$/i', $classes );
             if( !empty( $tmp_classes ) ){
                 $classes = array_values( array_diff( $classes, $tmp_classes ) );
             }
@@ -190,7 +190,7 @@ class FontAwesomeFive {
 
     function walker_nav_menu_start_el( $item_output, $item, $depth, $args ){
         if( is_array( $item->classes ) ){
-            $classes = preg_grep( '/^(fa)(-\S+)?$/i', $item->classes );
+            $classes = preg_grep( '/^(fa|fas|far|fal|fad|fab)(-\S+)?$/i', $item->classes );
             if( !empty( $classes ) ){
                 $item_output = $this->replace_item( $item_output, $classes );
             }


### PR DESCRIPTION
Using icons with Font Awesome 5 often requires to specify the type of icon as one of the following:
- fas -> Solid
- far -> Regular
- fal -> Light
- fad -> Duotone
- fab -> Brands
(see: https://fontawesome.com/how-to-use/on-the-web/referencing-icons/basic-use)

When adding these classes to your menu items they are not filtered and added to the span tag, rather they are left as a class in the li tag (WP menu-item), because they are not searched for. By changing the matching function, preg_grep, support for these 5 classes can be accomplished.